### PR TITLE
Fixed casing of UDP import to suppport case-sensitive file systems

### DIFF
--- a/arduino_workspace/libraries/SonyHttpCamera/SonyHttpCamera.h
+++ b/arduino_workspace/libraries/SonyHttpCamera/SonyHttpCamera.h
@@ -11,7 +11,7 @@
 #include <DebuggingSerial.h>
 
 //#include "AsyncHTTPRequest_Generic.hpp"
-#include <WiFiUDP.h>
+#include <WiFiUdp.h>
 #include <HTTPClient.h>
 
 #define SHCAM_RXBUFF_UNIT     64


### PR DESCRIPTION
Casing of import didn't match casing of actual file. On Windows/Mac this will work fine but Linux usually uses case-sensitive file systems. 